### PR TITLE
fix: Enclose svg tags within div tags

### DIFF
--- a/markdown_inline_graphviz.py
+++ b/markdown_inline_graphviz.py
@@ -107,7 +107,8 @@ class InlineGraphvizPreprocessor(markdown.preprocessors.Preprocessor):
 
             else:
                 break
-        return text.split("\n")
+        text_div_tags = text.replace("<svg", "<div><svg").replace("</svg>", "</svg></div>")
+        return text_div_tags.split("\n")
 
 
 def makeExtension(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import sys
 from setuptools import setup
 
-VERSION = '1.1'
+VERSION = '1.1.1'
 
 if sys.argv[-1] == 'publish':
     if os.system("pip freeze | grep wheel"):


### PR DESCRIPTION
## Summary

* This PR fixes the issue of svg files not rendering with markdown >=3.3
* The solution is to enclose the svg tags <svg> ... </svg> within div tags as [suggested](https://github.com/Python-Markdown/markdown/issues/1106#issuecomment-783393651) by the contributors of the markdown repository.
* As a result, the output string of the preprocessor now includes "\<div><svg" instead of "\<svg" and "\</svg></div>" instead of "\</svg>"

**Closes #6** 