### PR TITLE
Fix failing with exception

### DIFF
--- a/markdown_inline_graphviz.py
+++ b/markdown_inline_graphviz.py
@@ -65,7 +65,7 @@ class InlineGraphvizPreprocessor(markdown.preprocessors.Preprocessor):
                 command = m.group('command')
                 # Whitelist command, prevent command injection.
                 if command not in SUPPORTED_COMMAMDS:
-                    raise Exception('Command not supported: %s' % command)
+                    break
                 filename = m.group('filename')
                 content = m.group('content')
                 filetype = filename[filename.rfind('.')+1:]


### PR DESCRIPTION
Some template engines (like django) use syntax like `{% block %}`. This plugin makes it impossible to render documentation for such libraries. The solution to this is pretty simple. Instead of failing the entire rendering sequence, ignore a such block of text. 