### PR TITLE
Updated to work with Markdown>=3.0

### DIFF
--- a/markdown_inline_graphviz.py
+++ b/markdown_inline_graphviz.py
@@ -41,13 +41,12 @@ SUPPORTED_COMMAMDS = ['dot', 'neato', 'fdp', 'sfdp', 'twopi', 'circo']
 
 class InlineGraphvizExtension(markdown.Extension):
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Add InlineGraphvizPreprocessor to the Markdown instance. """
         md.registerExtension(self)
-
-        md.preprocessors.add('graphviz_block',
-                             InlineGraphvizPreprocessor(md),
-                             "_begin")
+        md.preprocessors.register(
+            InlineGraphvizPreprocessor(md), 'graphviz_block', 40
+        )
 
 
 class InlineGraphvizPreprocessor(markdown.preprocessors.Preprocessor):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     name="markdown_inline_graphviz_extension",
     version=VERSION,
     py_modules=["markdown_inline_graphviz"],
-    install_requires=['Markdown>=2.3.1'],
+    install_requires=['Markdown>=3.0'],
     author="Cesar Morel",
     author_email="cesaremoreln@gmail.com",
     description="Render inline graphs with Markdown and Graphviz (python3 version)",


### PR DESCRIPTION
This makes `Markdown>=3.0` a minimum requirement, and fixes the following warnings that were emitted when using this extension with `Markdown>=3.0`:
```
DeprecationWarning: Using the add method to register a processor or pattern is deprecated. Use the `register` method instead.
DeprecationWarning: The 'md_globals' parameter of 'markdown_inline_graphviz.InlineGraphvizExtension.extendMarkdown' is deprecated.
```

The value of `priority` was picked to be the same as in my install (installed via `mkdocs-techdocs-core`).